### PR TITLE
Skip converting the baseCurrency

### DIFF
--- a/code.js
+++ b/code.js
@@ -62,6 +62,11 @@ function refreshCurrencies_(
 
   currencyCodes.forEach(function(currencyCode) {
     if (convertToBase) {
+      // We won't get a result for converting the baseCurrency, rather a `#NA`
+      if(currencyCode === baseCurrency){
+        formulaTemplate = 1.00;
+      }
+      else {
       formulaTemplate =
           '=GoogleFinance("CURRENCY:' + currencyCode + baseCurrency + '")';
     } else {


### PR DESCRIPTION
We won't get a result for converting the `baseCurrency` into itself but rather a `#NA`. Let's save us from this mishap.