### PR TITLE
Cast Currency Rates to Strings in Lookup Table

### DIFF
--- a/code.js
+++ b/code.js
@@ -111,7 +111,7 @@ function buildLookupTable_(currencyRates, tableName) {
       'type': 'map',
       'map': [
         {'type': 'template', 'key': 'key', 'value': key},
-        {'type': 'template', 'key': 'value', 'value': currencyRates[key]}
+        {'type': 'template', 'key': 'value', 'value': '' + currencyRates[key]}
       ]
     });
   }


### PR DESCRIPTION
This change resolves the following error:

Error: Failed to update lookup table variable. Check validity of accountId,containerId, workspaceId and lookup variable id
    at publishLookupTable_(Code:189:11)
    at runSync(Code:45:3)

Resulting from nested exception:

GoogleJsonResponseException: API call to tagmanager.accounts.containers.workspaces.variables.update failed with error: Invalid value at 'variable.parameter[1].list[0].map[1].value' (TYPE_STRING), ...